### PR TITLE
Get RSS links with textContent instead of innerHTML

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -1449,7 +1449,7 @@ Client.parseFeedSourceResponse = async function(feedKey, fetchedUrl,
         let feedTitleElement = xmlDOM.querySelector("channel title") || xmlDOM.querySelector("feed title");
         let itemTitleElement = item.querySelector("title");
 
-        let href = link?.getAttribute("href") || link?.innerHTML || "#";
+        let href = link?.getAttribute("href") || link?.textContent || "#";
         let feedTitleText = feedTitleElement?.text || feedTitleElement?.childNodes[0]?.nodeValue || "unknown title";
         let itemTitleText = itemTitleElement?.text || itemTitleElement?.childNodes[0]?.nodeValue || href;
 


### PR DESCRIPTION
Some RSS feeds provide valid links wrapped in CDATA nodes to prevent special
characters (e.g. &) from getting interpreted incorrectly. Getting innerHTML from
these nodes will include the `![CDATA[` cruft and break the links. The
recommended way to get text content out of a node that may contain CDATA is to
use textContent.

https://developer.mozilla.org/en-US/docs/Web/API/Node/textContent